### PR TITLE
fix: remove useless `s`

### DIFF
--- a/pkg/structs/flamebearer/formatter.go
+++ b/pkg/structs/flamebearer/formatter.go
@@ -289,7 +289,7 @@ func NewBytesFormatter(maxBytes int) *BytesFormatter {
 		if maxBytes >= level[0] {
 			bf.Divider *= float64(level[0])
 			maxBytes /= level[0]
-			bf.Suffix = bf.getLevelName(level[1]) + "s"
+			bf.Suffix = bf.getLevelName(level[1])
 		} else {
 			break
 		}


### PR DESCRIPTION
![image](https://github.com/erda-project/pyroscope/assets/30427474/c59547e1-0ca7-4646-b431-68a51f404a3b)
![image](https://github.com/erda-project/pyroscope/assets/30427474/fc8d81fa-a4c3-40b2-85d7-1f56bda90f96)
